### PR TITLE
Add support for non-GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # A Log of Changes!
 
+## [1.4.0] - unreleased
+- Support non-GET requests via REQUEST_METHOD and setting body via REQUEST_BODY
+
+
 ## [1.3.4]
 
 - Allow for "warming up tasks" via WARM_COUNT env var #119

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.4.0] - unreleased
 - Support non-GET requests via REQUEST_METHOD and setting body via REQUEST_BODY
+- Add ability to set Content-Type and Content-Length headers via CONTENT_TYPE and CONTENT_LENGTH env vars (they don't work with HTTP_ variables)
 
 
 ## [1.3.4]

--- a/README.md
+++ b/README.md
@@ -438,6 +438,8 @@ $ HTTP_AUTHORIZATION="Basic YWRtaW46c2VjcmV0\n" \
   PATH_TO_HIT=/foo_secret bundle exec derailed exec perf:ips
 ```
 
+The `Content-Type` and `Content-Length` headers are a bit different. To set those, ignore the HTTP_ prefix, use the `CONTENT_TYPE` and `CONTENT_LENGTH` variables.
+
 ### Performing non-GET requests
 
 If the endpoint being tested is not a GET request, you can set the `REQUEST_METHOD` variable with the HTTP method you want (e.g. POST, PUT, PATCH, DELETE).
@@ -446,7 +448,8 @@ To set the request body, you can use the `REQUEST_BODY`.
 
 ```
 $ REQUEST_METHOD=POST \
-  REQUEST_BODY="user%5Bemail%5D=foo%40bar.com&user%password%5D=123456&user%password_confirmation%5D=123456" \
+  REQUEST_BODY="{\"user\":{\"email\":\"foo@bar.com\",\"password\":\"123456\",\"password_confirmation\":\"123456\"}}" \
+  CONTENT_TYPE="application/json" \
   PATH_TO_HIT=/users \
   bundle exec derailed exec perf:test
 ```

--- a/README.md
+++ b/README.md
@@ -438,6 +438,19 @@ $ HTTP_AUTHORIZATION="Basic YWRtaW46c2VjcmV0\n" \
   PATH_TO_HIT=/foo_secret bundle exec derailed exec perf:ips
 ```
 
+### Performing non-GET requests
+
+If the endpoint being tested is not a GET request, you can set the `REQUEST_METHOD` variable with the HTTP method you want (e.g. POST, PUT, PATCH, DELETE).
+
+To set the request body, you can use the `REQUEST_BODY`.
+
+```
+$ REQUEST_METHOD=POST \
+  REQUEST_BODY="user%5Bemail%5D=foo%40bar.com&user%password%5D=123456&user%password_confirmation%5D=123456" \
+  PATH_TO_HIT=/users \
+  bundle exec derailed exec perf:test
+```
+
 ### Using a real web server with `USE_SERVER`
 
 All tests are run without a webserver (directly using `Rack::Mock` by default), if you want to use a webserver set `USE_SERVER` to a Rack::Server compliant server, such as `webrick`.

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -83,6 +83,25 @@ class TasksTest < ActiveSupport::TestCase
     assert_match 'HTTP headers: {"Authorization"=>"Basic YWRtaW46c2VjcmV0\n", "Cache-Control"=>"no-cache"}', result
   end
 
+  test 'REQUEST_METHOD and REQUEST_BODY' do
+    env = {
+      "REQUEST_METHOD" => "POST",
+      "PATH_TO_HIT" => "users",
+      "REQUEST_BODY" => "user%5Bemail%5D=foo%40bar.com&user%5Bpassword%5D=123456&user%5Bpassword_confirmation%5D=123456",
+      "TEST_COUNT" => "2"
+    }
+
+    result = rake "perf:test", env: env
+    assert_match 'Endpoint: "users"', result
+    assert_match 'Method: POST', result
+    assert_match 'Body: user%5Bemail%5D=foo%40bar.com&user%5Bpassword%5D=123456&user%5Bpassword_confirmation%5D=123456', result
+
+    env["USE_SERVER"] = "webrick"
+    result = rake "perf:test", env: env
+    assert_match 'Method: POST', result
+    assert_match 'Body: user%5Bemail%5D=foo%40bar.com&user%5Bpassword%5D=123456&user%5Bpassword_confirmation%5D=123456', result
+  end
+
   test 'USE_SERVER' do
     result = rake "perf:test", env: { "USE_SERVER" => 'webrick', "TEST_COUNT" => "2" }
     assert_match 'Server: "webrick"', result

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -83,6 +83,25 @@ class TasksTest < ActiveSupport::TestCase
     assert_match 'HTTP headers: {"Authorization"=>"Basic YWRtaW46c2VjcmV0\n", "Cache-Control"=>"no-cache"}', result
   end
 
+  test 'CONTENT_TYPE' do
+    env = {
+      "REQUEST_METHOD" => "POST",
+      "PATH_TO_HIT" => "users",
+      "CONTENT_TYPE" => "application/json",
+      "REQUEST_BODY" => '{"user":{"email":"foo@bar.com","password":"123456","password_confirmation":"123456"}}',
+      "TEST_COUNT" => "2"
+    }
+
+    result = rake "perf:test", env: env
+    assert_match 'Body: {"user":{"email":"foo@bar.com","password":"123456","password_confirmation":"123456"}}', result
+    assert_match 'HTTP headers: {"Content-Type"=>"application/json"}', result
+
+    env["USE_SERVER"] = "webrick"
+    result = rake "perf:test", env: env
+    assert_match 'Body: {"user":{"email":"foo@bar.com","password":"123456","password_confirmation":"123456"}}', result
+    assert_match 'HTTP headers: {"Content-Type"=>"application/json"}', result
+  end
+
   test 'REQUEST_METHOD and REQUEST_BODY' do
     env = {
       "REQUEST_METHOD" => "POST",

--- a/test/rails_app/app/controllers/users_controller.rb
+++ b/test/rails_app/app/controllers/users_controller.rb
@@ -1,0 +1,13 @@
+class UsersController < ApplicationController
+  def create
+    User.create!(user_params)
+
+    head :created
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password, :password_confirmation)
+  end
+end

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -54,6 +54,7 @@ Dummy::Application.routes.draw do
 
   get "foo", to: "pages#index"
   get "foo_secret", to: "pages#secret"
+  post "users", to: "users#create"
 
   get "authenticated", to: "authenticated#index"
 


### PR DESCRIPTION
This is a solution for #121. I needed this myself while running some perf tests this week, so I took the opportunity to patch the gem, clean up and add tests.

I also had to find a way to set the `Content-Type` header, because the request I was testing was a JSON request and the gem did not support setting that header through `HTTP_` variables (looks like it's a [restriction from Rack](https://www.rubydoc.info/github/rack/rack/file/SPEC#The_Environment), actually).

Another thing I had to do was disable the CSRF protection before initializing the app. I did that because non-GET requests require an authenticity token and I couldn't find a way to generate a valid one from the `Rails.application` context. I'm open to suggestions.

I really appreciate the work you've done with this gem @schneems (and everyone else who has contributed), it has helped me so much to investigate and find the memory leaks. It felt like I had everything I needed in a single tool. 🙂👏 