### PR TITLE
Failing test: Bundler re-writes gem spec when installing a git gem:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ gemfile:
   - gemfiles/rails_5_2.gemfile
   - gemfiles/rails_6_0.gemfile
   - gemfiles/rails_git.gemfile
+  - gemfiles/rails_branch.gemfile
 
 before_install:
   - gem install bundler

--- a/gemfiles/rails_branch.gemfile
+++ b/gemfiles/rails_branch.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# $ BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_branch.gemfile" bundle exec m test/integration/tasks_test.rb:30
+
+source "https://rubygems.org"
+
+gem "rails", github: "rails/rails", ref: "3054e1d584e7eca110c69a1f8423f2e0866abbf9"
+gem 'devise'
+gem 'wicked', github: "zombocom/wicked", branch: "schneems/do-not-delete"
+
+group :development, :test do
+  gem "sqlite3", platform: [:ruby, :mswin, :mingw]
+  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.13", platform: :jruby
+  gem "test-unit", "~> 3.0"
+end
+
+gemspec path: "../"
+
+ENV['USING_RAILS_WICKED_BRANCH'] = "1"

--- a/lib/derailed_benchmarks.rb
+++ b/lib/derailed_benchmarks.rb
@@ -45,6 +45,7 @@ require 'derailed_benchmarks/auth_helper'
 
 require 'derailed_benchmarks/stats_in_file'
 require 'derailed_benchmarks/stats_from_dir'
+require 'derailed_benchmarks/git_switch_project'
 
 if DerailedBenchmarks.gem_is_bundled?("devise")
   DerailedBenchmarks.auth = DerailedBenchmarks::AuthHelpers::Devise.new

--- a/lib/derailed_benchmarks/git_switch_project.rb
+++ b/lib/derailed_benchmarks/git_switch_project.rb
@@ -1,0 +1,164 @@
+module DerailedBenchmarks
+  # Represents a specific commit in a git repo
+  #
+  # Can be used to get information from the commit or to check it out
+  #
+  # commit = GitCommit.new(path: "path/to/repo", sha: "6e642963acec0ff64af51bd6fba8db3c4176ed6e")
+  # commit.short_sha # => "6e64296"
+  # commit.checkout! # Will check out the current commit at the repo in the path
+  class GitCommit
+    attr_reader :sha, :description, :time, :short_sha, :log
+
+    def initialize(path: , sha: , log_dir: Pathname.new("/dev/null"))
+      @sha = sha
+      @path = path
+      @meta = {}
+      @log = nil
+
+      Dir.chdir(@path) do
+        checkout!
+        @description = run!("git log --oneline --format=%B -n 1 HEAD | head -n 1")
+        @short_sha   = run!("git rev-parse --short HEAD")
+        @log         = log_dir.join("#{file_safe_sha}.bench.txt")
+
+        time_stamp  = run!("git log -n 1 --pretty=format:%ci") # https://stackoverflow.com/a/25921837/147390
+        @time = DateTime.parse(time_stamp)
+      end
+    end
+
+    alias :desc :description
+    alias :file :log
+
+    def checkout!
+      run!("cd #{@path} && git checkout '#{sha}' 2>&1")
+    end
+
+    private def file_safe_sha
+      sha.gsub('/', ':')
+    end
+
+    private def run!(cmd)
+      out = `#{cmd}`.strip
+      raise "Error while running #{cmd.inspect}: #{out}" unless $?.success?
+      out
+    end
+  end
+
+  # Wraps two or more git commits in a specific location
+  #
+  # Returns an array of GitCommit objects that can be used to manipulate
+  # and checkout the repo
+  #
+  # Example:
+  #
+  #   `git clone https://sharpstone/default_ruby tmp/default_ruby`
+  #
+  #   project = GitSwitchProject.new(path: "tmp/default_ruby")
+  #
+  # By default it will represent the last two commits:
+  #
+  #   project.commits.length # => 2
+  #
+  # You can pass in explicit SHAs in an array:
+  #
+  #   sha_array = ["da748a59340be8b950e7bbbfb32077eb67d70c3c", "9b19275a592f148e2a53b87ead4ccd8c747539c9"]
+  #   project = GitSwitchProject.new(path: "tmp/default_ruby", sha_array: sha_array)
+  #
+  #   puts project.commits.map(&:sha) == sha_array # => true
+  #
+  #
+  # It knows the current branch or sha:
+  #
+  #    `cd tmp/ruby && git checkout -b mybranch`
+  #    project.current_branch_or_sha #=> "mybranch"
+  #
+  # It can be used for safely wrapping checkouts to ensure the project returns to it's original branch:
+  #
+  #    project.restore_branch_on_return do
+  #      project.commits.first.checkout!
+  #      project.current_branch_or_sha # => "da748a593"
+  #    end
+  #
+  #    project.current_branch_or_sha # => "mybranch"
+  class GitSwitchProject
+    attr_reader :commits
+
+    def initialize(path: , sha_array: [], io: STDOUT, log_dir: nil)
+      @path = Pathname.new(path)
+
+      raise "Must be a path with a .git directory '#{@path}'" if !@path.join(".git").exist?
+      @io = io
+      @commits = []
+      log_dir = Pathname(log_dir || "/dev/null")
+
+      expand_shas(sha_array).each do |sha|
+        restore_branch_on_return(quiet: true) do
+          @commits << GitCommit.new(path: @path, sha: sha, log_dir: log_dir)
+        end
+      end
+    end
+
+    def current_branch_or_sha
+      out = run!("cd #{@path} && git rev-parse --abbrev-ref HEAD")
+      out == "HEAD" ? run!("cd #{@path} && git rev-parse --short HEAD") : out
+    end
+
+    def dirty?
+      !clean?
+    end
+
+    # https://stackoverflow.com/a/3879077/147390
+    def clean?
+      `cd #{@path} && git diff-index --quiet HEAD --` && $?.success?
+    end
+
+    private def status(pattern: "*.gemspec")
+      run!("cd #{@path} && git status #{pattern}")
+    end
+
+    def restore_branch_on_return(quiet: false)
+      if dirty? && status.include?("gemspec")
+        dirty_gemspec = true
+        unless quiet
+          @io.puts "Working tree at #{@path} is dirty, stashing. This will be popped on return"
+          @io.puts "Bundler modifies gemspec files on git install, this is normal"
+          @io.puts "Original status:\n#{status}"
+        end
+        run!("cd #{@path} && git stash")
+      end
+      sha_ish = self.current_branch_or_sha
+      yield
+    ensure
+      return unless sha_ish
+      @io.puts "Resetting git dir of '#{@path.to_s}' to #{sha_ish.inspect}" unless quiet
+      run!("cd #{@path} && git checkout '#{sha_ish}' 2>&1")
+      if dirty_gemspec
+        out = run!("cd #{@path} && git stash pop 2>&1")
+        @io.puts "Popping stash of '#{@path.to_s}':\n#{out}" unless quiet
+      end
+    end
+
+    # case sha_array.length
+    # when >= 2
+    #   returns original array
+    # when 1
+    #   returns the given sha plus the one before it
+    # when 0
+    #   returns the most recent 2 shas
+    private def expand_shas(sha_array)
+      return sha_array if sha_array.length >= 2
+
+      run!("cd #{@path} && git checkout '#{sha_array.first}' 2>&1") if sha_array.first
+
+      branches_string = run!("cd #{@path} && git log --format='%H' -n 2")
+      sha_array = branches_string.split($/)
+      return sha_array
+    end
+
+    private def run!(cmd)
+      out = `#{cmd}`.strip
+      raise "Error while running #{cmd.inspect}: #{out}" unless $?.success?
+      out
+    end
+  end
+end

--- a/lib/derailed_benchmarks/git_switch_project.rb
+++ b/lib/derailed_benchmarks/git_switch_project.rb
@@ -96,6 +96,10 @@ module DerailedBenchmarks
           @commits << GitCommit.new(path: @path, sha: sha, log_dir: log_dir)
         end
       end
+
+      if (duplicate = @commits.group_by(&:short_sha).detect {|(k, v)| v.length > 1})
+        raise "Duplicate SHA resolved #{duplicate[0].inspect}: #{duplicate[1].map {|c| "'#{c.sha}' => '#{c.short_sha}'"}.join(", ") } at #{@path}"
+      end
     end
 
     def current_branch_or_sha

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -146,11 +146,11 @@ module DerailedBenchmarks
         io.puts "👎👎👎(NOT Statistically Significant) 👎👎👎"
       end
       io.puts
-      io.puts "[#{newest.name}] #{newest.desc.inspect} - (#{newest.median} seconds)"
+      io.puts "[#{newest.name}] #{newest.desc.inspect} (#{newest.median} seconds)"
       io.puts "  #{change_direction} by:"
       io.puts "    #{align}#{FORMAT % x_faster}x [older/newer]"
       io.puts "    #{FORMAT % percent_faster}\% [(older - newer) / older * 100]"
-      io.puts "[#{oldest.name}] #{oldest.desc.inspect} - (#{oldest.median} seconds)"
+      io.puts "[#{oldest.name}] #{oldest.desc.inspect} (#{oldest.median} seconds)"
       io.puts
       io.puts "Iterations per sample: #{ENV["TEST_COUNT"]}"
       io.puts "Samples: #{newest.values.length}"

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -58,6 +58,8 @@ module DerailedBenchmarks
     def call
       @files.each(&:call)
 
+      return self if @files.detect(&:empty?)
+
       stats_95 = statistical_test(confidence: 95)
 
       # If default check is good, see if we also pass a more rigorous test
@@ -135,6 +137,8 @@ module DerailedBenchmarks
     end
 
     def banner(io = $stdout)
+      return if @files.detect(&:empty?)
+
       io.puts
       if significant?
         io.puts "❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️"

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -29,14 +29,26 @@ module DerailedBenchmarks
     FORMAT = "%0.4f"
     attr_reader :stats, :oldest, :newest
 
-    def initialize(hash)
+    def initialize(input)
       @files = []
 
-      hash.each do |branch, info_hash|
-        file = info_hash.fetch(:file)
-        desc = info_hash.fetch(:desc)
-        time = info_hash.fetch(:time)
-        @files << StatsForFile.new(file: file, desc: desc, time: time, name: branch)
+      if input.is_a?(Hash)
+        hash = input
+        hash.each do |branch, info_hash|
+          file = info_hash.fetch(:file)
+          desc = info_hash.fetch(:desc)
+          time = info_hash.fetch(:time)
+          @files << StatsForFile.new(file: file, desc: desc, time: time, name: branch)
+        end
+      else
+        input.each do |commit|
+          @files << StatsForFile.new(
+            file: commit.file,
+            desc: commit.desc,
+            time: commit.time,
+            name: commit.sha
+          )
+        end
       end
       @files.sort_by! { |f| f.time }
       @oldest = @files.first

--- a/lib/derailed_benchmarks/stats_in_file.rb
+++ b/lib/derailed_benchmarks/stats_in_file.rb
@@ -29,9 +29,14 @@ module DerailedBenchmarks
 
     def call
       load_file!
+      return if values.empty?
 
       @median = (values[(values.length - 1) / 2] + values[values.length/ 2]) / 2.0
       @average = values.inject(:+) / values.length
+    end
+
+    def empty?
+      values.empty?
     end
 
     def median

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -42,14 +42,14 @@ namespace :perf do
       puts
       puts
 
-      run!("#{script}") # Run once without pipe to make sure the script works for better error message
-
       project.restore_branch_on_return do
         DERAILED_SCRIPT_COUNT.times do |i|
           puts "Sample: #{i.next}/#{DERAILED_SCRIPT_COUNT} iterations per sample: #{ENV['TEST_COUNT']}"
           project.commits.each do |commit|
             commit.checkout!
-            run!(" #{script} 2>&1 | tail -n 1 >> '#{commit.log}'")
+
+            output = run!("#{script} 2>&1")
+            commit.log.open("a") {|f| f.puts output.lines.last }
           end
 
           if (i % 50).zero?

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -31,6 +31,7 @@ namespace :perf do
         sha_array: ENV.fetch("SHAS_TO_TEST", "").split(","),
         log_dir: out_dir
       )
+
       stats = DerailedBenchmarks::StatsFromDir.new(project.commits)
 
       # Advertise branch names early to make sure people know what they're testing
@@ -54,8 +55,7 @@ namespace :perf do
 
           if (i % 50).zero?
             puts "Intermediate result"
-            stats.call
-            stats.banner
+            stats.call.banner
             puts "Continuing execution"
           end
         end
@@ -63,8 +63,7 @@ namespace :perf do
 
     ensure
       if stats
-        stats.call
-        stats.banner
+        stats.call.banner
 
         result_file = out_dir.join("results.txt")
         File.open(result_file, "w") do |f|

--- a/test/derailed_benchmarks/git_switch_project_test.rb
+++ b/test/derailed_benchmarks/git_switch_project_test.rb
@@ -72,6 +72,13 @@ class GitSwitchProjectTest < ActiveSupport::TestCase
       end
 
       assert_equal project.commits.first.short_sha, project.current_branch_or_sha
+
+
+      exception = assert_raise {
+        DerailedBenchmarks::GitSwitchProject.new(path: dir, sha_array: ["6e642963acec0ff64af51bd6fba8db3c4176ed6e", "mybranch"])
+      }
+
+      assert_includes(exception.message, 'Duplicate SHA resolved "6e64296"')
     end
   end
 end

--- a/test/derailed_benchmarks/git_switch_project_test.rb
+++ b/test/derailed_benchmarks/git_switch_project_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GitSwitchProjectTest < ActiveSupport::TestCase
+  test "tells me when it's not pointing at a git project" do
+    exception = assert_raises {
+      DerailedBenchmarks::GitSwitchProject.new(path: "/dev/null")
+    }
+    assert_includes(exception.message, '.git directory')
+  end
+
+  test "dirty gemspec cleaning" do
+    Dir.mktmpdir do |dir|
+      run!("git clone https://github.com/sharpstone/default_ruby #{dir} 2>&1 && cd #{dir} && git checkout 6e642963acec0ff64af51bd6fba8db3c4176ed6e 2>&1 && git checkout -b mybranch 2>&1")
+      run!("cd #{dir} && echo lol > foo.gemspec && git add .")
+
+      io = StringIO.new
+      project = DerailedBenchmarks::GitSwitchProject.new(path: dir, io: io)
+
+      assert project.dirty?
+      refute project.clean?
+
+      project.restore_branch_on_return do
+        project.commits.map(&:checkout!)
+      end
+
+      assert_includes io.string, "Bundler modifies gemspec files"
+      assert_includes io.string, "Popping stash"
+    end
+  end
+
+  test "finds shas when none given" do
+    Dir.mktmpdir do |dir|
+      run!("git clone https://github.com/sharpstone/default_ruby #{dir} 2>&1 && cd #{dir} && git checkout 6e642963acec0ff64af51bd6fba8db3c4176ed6e 2>&1 && git checkout -b mybranch 2>&1")
+
+      # finds shas when none given
+      project = DerailedBenchmarks::GitSwitchProject.new(path: dir)
+
+      assert_equal ["6e642963acec0ff64af51bd6fba8db3c4176ed6e", "da748a59340be8b950e7bbbfb32077eb67d70c3c"], project.commits.map(&:sha)
+      first_commit = project.commits.first
+
+      assert_equal "CI test support", first_commit.description
+      assert_equal "6e64296", first_commit.short_sha
+      assert_equal "/dev/null/6e642963acec0ff64af51bd6fba8db3c4176ed6e.bench.txt", first_commit.log.to_s
+      assert_equal DateTime.parse("Tue, 14 Apr 2020 13:26:03 -0500"), first_commit.time
+
+      assert_equal "mybranch", project.current_branch_or_sha
+
+      # Finds shas when 1 is given
+      project = DerailedBenchmarks::GitSwitchProject.new(path: dir, sha_array: ["da748a59340be8b950e7bbbfb32077eb67d70c3c"])
+
+      assert_equal ["da748a59340be8b950e7bbbfb32077eb67d70c3c", "5c09f748957d2098182762004adee27d1ff83160"], project.commits.map(&:sha)
+
+
+      # Returns correct shas if given
+      project = DerailedBenchmarks::GitSwitchProject.new(path: dir, sha_array: ["da748a59340be8b950e7bbbfb32077eb67d70c3c", "9b19275a592f148e2a53b87ead4ccd8c747539c9"])
+
+      assert_equal ["da748a59340be8b950e7bbbfb32077eb67d70c3c", "9b19275a592f148e2a53b87ead4ccd8c747539c9"], project.commits.map(&:sha)
+
+      first_commit = project.commits.first
+
+      first_commit.checkout!
+
+      assert_equal first_commit.short_sha, project.current_branch_or_sha
+
+      # Test restore_branch_on_return
+      project.restore_branch_on_return(quiet: true) do
+        project.commits.last.checkout!
+
+        assert_equal project.commits.last.short_sha, project.current_branch_or_sha
+      end
+
+      assert_equal project.commits.first.short_sha, project.current_branch_or_sha
+    end
+  end
+end

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -3,6 +3,19 @@
 require 'test_helper'
 
 class StatsFromDirTest < ActiveSupport::TestCase
+  test "empty files" do
+    Dir.mktmpdir do |dir|
+      dir = Pathname.new(dir)
+      branch_info = {}
+      branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser"), name: "loser" }
+      branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner"), name: "winner" }
+      stats = DerailedBenchmarks::StatsFromDir.new(branch_info).call
+      io = StringIO.new
+      stats.call.banner(io: io) # Doesn't error
+      assert_equal "", io.read
+    end
+  end
+
   test "that it works" do
     dir = fixtures_dir("stats/significant")
     branch_info = {}

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -43,6 +43,8 @@ class TasksTest < ActiveSupport::TestCase
   end
 
   test 'rails perf:library from git' do
+    # BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:<linenumber>
+
     skip unless ENV['USING_RAILS_GIT']
 
     env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2, "SHAS_TO_TEST" => "3054e1d584e7eca110c69a1f8423f2e0866abbf9,80f989aecece1a2b1830e9c953e5887421b52d3c"}

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -48,8 +48,10 @@ class TasksTest < ActiveSupport::TestCase
 
     skip unless ENV['USING_RAILS_GIT']
 
-    env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2, "SHAS_TO_TEST" => "3054e1d584e7eca110c69a1f8423f2e0866abbf9,80f989aecece1a2b1830e9c953e5887421b52d3c"}
+    env = { "TEST_COUNT" => 2, "DERAILED_SCRIPT_COUNT" => 2, "SHAS_TO_TEST" => "3054e1d584e7eca110c69a1f8423f2e0866abbf9,80f989aecece1a2b1830e9c953e5887421b52d3c"}
     puts rake "perf:library", { env: env }
+
+  end
 
   test "rails perf:library with bad script" do
     # BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:<linenumber>

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -34,7 +34,15 @@ class TasksTest < ActiveSupport::TestCase
     result
   end
 
-  test 'library_branches' do
+  test 'non-rails library with branch specified' do
+    skip unless ENV['USING_RAILS_WICKED_BRANCH']
+
+    gem_path = run!("bundle info wicked --path")
+    env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2, "DERAILED_PATH_TO_LIBRARY" => gem_path}
+    puts rake "perf:library", { env: env }
+  end
+
+  test 'rails perf:library from git' do
     skip unless ENV['USING_RAILS_GIT']
 
     env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2, "SHAS_TO_TEST" => "3054e1d584e7eca110c69a1f8423f2e0866abbf9,80f989aecece1a2b1830e9c953e5887421b52d3c"}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,3 +63,9 @@ end
 def rails_app_path(name = "")
   root_path("test/rails_app").join(name)
 end
+
+def run!(cmd)
+  output = `#{cmd}`
+  raise "Cmd #{cmd} failed:\n#{output}" unless $?.success?
+  output
+end


### PR DESCRIPTION
Bundler re-writes gem spec when installing a git gem:

https://twitter.com/schneems/status/1304138043419287552

Derailed benchmarks uses git to switch between commits to benchmark code changes in a library. This was originally written to benchmark changes in Rails, but it can be used for any library.

This feature fails when using a combination of:

- Bundler specifying a git dependency
- That git dependency modified gemspec 

To recreate this failure mode I've made an intentional commit on a branch in the wicked gem:

https://github.com/zombocom/wicked/commit/10e5dd18bf8a7792b57ace0fdd27b363951b364f

What happens when the `perf:library` command executes is derailed will `cd` into the wicked directory and checkout a this commit, but this happens on top of an already modified gem spec (due to bundler).

The first checkout succeeds (because it is already HEAD)

```
⛄ 2.7.1 🚀  ~/.gem/ruby/2.7.1/bundler/gems/wicked-10e5dd18bf8a (main)
$ git checkout 10e5dd18bf8a7792b57ace0fdd27b363951b364f
M	wicked.gemspec
Note: switching to '10e5dd18bf8a7792b57ace0fdd27b363951b364f'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 10e5dd1 Modifying gem spec intentionally
```

But the second checkout fails:

```
$ git checkout 4b8d7f605dcecbf813226e87adac6c7d9ef22064
error: Your local changes to the following files would be overwritten by checkout:
	wicked.gemspec
Please commit your changes or stash them before you switch branches.
Aborting
```

Here's the full test failure.


```
$ BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_branch.gemfile" bundle exec m test/integration/tasks_test.rb:37
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: The called method `initialize' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/transactions.rb:212: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:260: warning: The called method `transaction' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:171: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:97: warning: The called method `initialize' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/persistence.rb:705: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/timestamp.rb:105: warning: The called method `_update_record' is defined here
Run options: -n "/^(test_non\\-rails_library_with_branch_specified)$/" --seed 20635

# Running:

Running: bundle info wicked --path
The dependency activerecord-jdbcsqlite3-adapter (~> 1.3.13) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform java`.
Running: env TEST_COUNT=10 DERAILED_SCRIPT_COUNT=2 DERAILED_PATH_TO_LIBRARY=/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/wicked-10e5dd18bf8a'
' bundle exec rake -f perf.rake perf:library --trace
** Invoke perf:library (first_time)
** Execute perf:library
Note: switching to '10e5dd18bf8a7792b57ace0fdd27b363951b364f'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 10e5dd1 Modifying gem spec intentionally
The dependency activerecord-jdbcsqlite3-adapter (~> 1.3.13) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform java`.
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: The called method `initialize' is defined here
Database 'db/production.sqlite3' already exists
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/transactions.rb:212: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:260: warning: The called method `transaction' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:171: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:97: warning: The called method `initialize' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/persistence.rb:705: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activerecord/lib/active_record/timestamp.rb:105: warning: The called method `_update_record' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/actionview/lib/action_view/view_paths.rb:11: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/actionview/lib/action_view/lookup_context.rb:128: warning: The called method `template_exists?' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activesupport/lib/active_support/messages/rotator.rb:28: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activesupport/lib/active_support/messages/rotator.rb:6: warning: The called method `initialize' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/actionpack/lib/action_dispatch/middleware/cookies.rb:647: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activesupport/lib/active_support/message_encryptor.rb:150: warning: The called method `encrypt_and_sign' is defined here
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activesupport/lib/active_support/message_encryptor.rb:175: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/rails-3054e1d584e7/activesupport/lib/active_support/messages/metadata.rb:17: warning: The called method `wrap' is defined here
error: Your local changes to the following files would be overwritten by checkout:
	wicked.gemspec
Please commit your changes or stash them before you switch branches.
Aborting
Switched to branch 'main'
rake aborted!
Error while running "git checkout '4b8d7f605dcecbf813226e87adac6c7d9ef22064'":
/Users/rschneeman/Documents/projects/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:292:in `run!'
/Users/rschneeman/Documents/projects/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:58:in `block (4 levels) in <top (required)>'
/Users/rschneeman/Documents/projects/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:57:in `chdir'
/Users/rschneeman/Documents/projects/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:57:in `block (3 levels) in <top (required)>'
/Users/rschneeman/Documents/projects/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:56:in `each'
/Users/rschneeman/Documents/projects/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:56:in `block (2 levels) in <top (required)>'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/task.rb:281:in `block in execute'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/task.rb:281:in `each'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/task.rb:281:in `execute'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/task.rb:199:in `synchronize'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/task.rb:188:in `invoke'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:160:in `invoke_task'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:116:in `each'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:116:in `block in top_level'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:125:in `run_with_threads'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:110:in `top_level'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:83:in `block in run'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:186:in `standard_exception_handling'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/lib/rake/application.rb:80:in `run'
/Users/rschneeman/.gem/ruby/2.7.1/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/Users/rschneeman/.gem/ruby/2.7.1/bin/rake:23:in `load'
/Users/rschneeman/.gem/ruby/2.7.1/bin/rake:23:in `<top (required)>'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/cli.rb:476:in `exec'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/cli.rb:24:in `start'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:46:in `block in <top (required)>'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:34:in `<top (required)>'
/Users/rschneeman/.gem/ruby/2.7.1/bin/bundle:23:in `load'
/Users/rschneeman/.gem/ruby/2.7.1/bin/bundle:23:in `<main>'
Tasks: TOP => perf:library
F

Failure:
TasksTest#test_non-rails_library_with_branch_specified [/Users/rschneeman/Documents/projects/derailed_benchmarks/test/integration/tasks_test.rb:31]:
Expected 'env TEST_COUNT=10 DERAILED_SCRIPT_COUNT=2 DERAILED_PATH_TO_LIBRARY=/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/wicked-10e5dd18bf8a'
' bundle exec rake -f perf.rake perf:library --trace' to return a success status.
Output: Resetting git dir of '/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/wicked-10e5dd18bf8a' to "main"



bin/rails test /Users/rschneeman/Documents/projects/derailed_benchmarks/test/integration/tasks_test.rb:37



Finished in 4.183385s, 0.2390 runs/s, 0.2390 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```