### PR TITLE
Allow running tasks without requiring all/any of rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,11 +595,13 @@ Note: this plugs in the given webserver directly into rack, it doesn't use any `
 
 ### Excluding ActiveRecord
 
-By default, derailed will load ActiveRecord if the gem is included as a dependency.  It is included by default, if you just include the `rails` gem.  If you are using a different ORM, you will either need to only include the `railties` gem, or set the `DERAILED_SKIP_ACTIVE_RECORD` flag.
+By default, derailed will load ActiveRecord if the gem is included as a dependency.  It is included by default, if you just include the `rails` gem.  If you are using a different ORM, you will either need to only include the `railties` gem, or set the `DERAILED_SKIP_ACTIVE_RECORD` environment variable.
 
 ```
 $ DERAILED_SKIP_ACTIVE_RECORD=true
 ```
+
+Alternatively, use the `DERAILED_SKIP_RAILS_REQUIRES` environment variable to have derailed not require any Rails gems. Your app will then need to require them as part of its boot sequence.
 
 ### Running in a different environment
 

--- a/bin/derailed
+++ b/bin/derailed
@@ -80,9 +80,10 @@ class DerailedBenchmarkCLI < Thor
       require 'bundler/setup'
 
       begin
-        if ENV["DERAILED_SKIP_ACTIVE_RECORD"]
+        if ENV["DERAILED_SKIP_RAILS_REQUIRES"]
+          # do nothing. your app will handle requiring Rails for booting.
+        elsif ENV["DERAILED_SKIP_ACTIVE_RECORD"]
           require "action_controller/railtie"
-          require "action_mailer/railtie"
           require "sprockets/railtie"
           require "rails/test_unit/railtie"
         else


### PR DESCRIPTION
- Remove initial action mailer require, per https://github.com/zombocom/derailed_benchmarks/pull/60#issuecomment-169848795
- Add an ENV var that allows you to not do any additional requires here, so that it's all handled by the Rails app

The new ENV is useful if you want to do stuff like this in `config/application.rb`:

![image](https://user-images.githubusercontent.com/509837/128544827-6f4c97f8-ebb4-462e-820a-40f3fb6434a5.png)

Currently `derailed` will still report some of the gems as being used even if they are not, since it requires them itself!