### PR TITLE
support rails 7 for `bundle exec derailed exec mem`

### DIFF
--- a/lib/derailed_benchmarks/load_tasks.rb
+++ b/lib/derailed_benchmarks/load_tasks.rb
@@ -40,9 +40,9 @@ namespace :perf do
       ActiveRecord::Migrator.migrations_paths = DERAILED_APP.paths['db/migrate'].to_a
       ActiveRecord::Migration.verbose         = true
 
-      if Rails.version.start_with? '6'
+      if Rails.version.start_with?('6.') || Rails.version.start_with?('7.')
         ActiveRecord::MigrationContext.new(ActiveRecord::Migrator.migrations_paths, ActiveRecord::SchemaMigration).migrate
-      elsif Rails.version.start_with? '5.2'
+      elsif Rails.version.start_with?('5.2')
         ActiveRecord::MigrationContext.new(ActiveRecord::Migrator.migrations_paths).migrate
       else
         ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, nil)

--- a/lib/derailed_benchmarks/load_tasks.rb
+++ b/lib/derailed_benchmarks/load_tasks.rb
@@ -40,7 +40,7 @@ namespace :perf do
       ActiveRecord::Migrator.migrations_paths = DERAILED_APP.paths['db/migrate'].to_a
       ActiveRecord::Migration.verbose         = true
 
-      if Rails.version.start_with?('6.') || Rails.version.start_with?('7.')
+      if Rails.version >= "6.0"
         ActiveRecord::MigrationContext.new(ActiveRecord::Migrator.migrations_paths, ActiveRecord::SchemaMigration).migrate
       elsif Rails.version.start_with?('5.2')
         ActiveRecord::MigrationContext.new(ActiveRecord::Migrator.migrations_paths).migrate


### PR DESCRIPTION
was getting:

/Users/dorianmariefr/.rvm/gems/ruby-3.0.3/gems/derailed_benchmarks-2.1.1/lib/derailed_benchmarks/load_tasks.rb:48:in `block (2 levels) in <top (required)>': undefined method `migrate' for ActiveRecord::Migrator:Class (NoMethodError)