### PR TITLE
Update the gemspec's homepage to the current repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Update the gemspec's homepage to the current repo URL
+
 ## 2.1.1
 
 - Fix Thor's deprecation warning by implementing `exit_on_failure?` (https://github.com/schneems/derailed_benchmarks/pull/195)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD
 
-- Update the gemspec's homepage to the current repo URL
+- Update the gemspec's homepage to the current repo URL (https://github.com/zombocom/derailed_benchmarks/pull/212)
 
 ## 2.1.1
 

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["richard.schneeman+rubygems@gmail.com"]
   gem.description   = %q{ Go faster, off the Rails }
   gem.summary       = %q{ Benchmarks designed to performance test your ENTIRE site }
-  gem.homepage      = "https://github.com/schneems/derailed_benchmarks"
+  gem.homepage      = "https://github.com/zombocom/derailed_benchmarks"
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
This reduces unnecessary redirection when someone visits this gem's homepage via https://rubygems.org/gems/derailed_benchmarks some tools or APIs that use the gem's metadata.