### PR TITLE
update requirement in `lib/derailed_benchamrks/stats_from_dir.rb`

### DIFF
--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack",            ">= 1"
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
-  gem.add_dependency "ruby-statistics", ">= 2.1"
+  gem.add_dependency "ruby-statistics", ">= 4.0"
   gem.add_dependency "mini_histogram",  ">= 0.3.0"
   gem.add_dependency "dead_end",        ">= 0"
   gem.add_dependency "rack-test",       ">= 0"

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'bigdecimal'
-require 'statistics'
+require 'ruby-statistics'
 require 'stringio'
 require 'mini_histogram'
 require 'mini_histogram/plot'


### PR DESCRIPTION
as mentioned in the issue
https://github.com/zombocom/derailed_benchmarks/issues/237 by @espen, the `ruby-statistics` gem updated the namespace of their gem from `statistics` to `ruby-statistics`
https://github.com/estebanz01/ruby-statistics/commit/baadc9fd3bd90c9ed14e2bba48b8eb806bfe1ff2 and
https://github.com/estebanz01/ruby-statistics/commit/00312b9a329c742c2b851a182d3ab35bb86fe535 this commit is addressing the change