### PR TITLE
Replace statistics require for ruby-statistics as it fails on Rails 7.2

### DIFF
--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack",            ">= 1"
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
-  gem.add_dependency "ruby-statistics", ">= 2.1"
+  gem.add_dependency "ruby-statistics", ">= 4.0"
   gem.add_dependency "mini_histogram",  ">= 0.3.0"
   gem.add_dependency "dead_end",        ">= 0"
   gem.add_dependency "rack-test",       ">= 0"

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'bigdecimal'
-require 'statistics'
+require 'ruby-statistics'
 require 'stringio'
 require 'mini_histogram'
 require 'mini_histogram/plot'


### PR DESCRIPTION
Pull request to replace the current require for `statistics` gem for `ruby-statistics`. I've updated the `gemspec` but I did not update the gem version for a breaking change version. Let me know if you want me to amend this PR and changing the version.
Not sure if happen to other but running a Rails app 7.2 version failed due to this change on` ruby-statistics`.
[ISSUE-237](https://github.com/zombocom/derailed_benchmarks/issues/237)
