### PR TITLE
support relative gemfile reference when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         - ruby: "head"
           gemfile: gemfiles/rails_head.gemfile
     env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Test Rails 7.1 and 7.2 (https://github.com/zombocom/derailed_benchmarks/pull/242)
 - Switch from dead_end to syntax_suggest (https://github.com/zombocom/derailed_benchmarks/pull/243)
 - require `ruby2_keywords` so drb doesn't break in ruby < 2.7 (https://github.com/zombocom/derailed_benchmarks/pull/244)
+- support relative BUNDLE_GEMFILE in tests (https://github.com/zombocom/derailed_benchmarks/pull/245)
 
 ## 2.1.2
 

--- a/gemfiles/rails_head.gemfile
+++ b/gemfiles/rails_head.gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# $ BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:50
+# $ BUNDLE_GEMFILE="gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:50
 
 source "https://rubygems.org"
 

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -26,7 +26,11 @@ class TasksTest < ActiveSupport::TestCase
     env_string = env.map {|key, value| "#{key.shellescape}=#{value.to_s.shellescape}" }.join(" ")
     cmd        = "env #{env_string} bundle exec rake -f perf.rake #{cmd} --trace"
     puts "Running: #{cmd}"
-    result = Bundler.with_original_env { `cd '#{rails_app_path}' && #{cmd} 2>&1` }
+    result = Bundler.with_original_env do
+      # Ensure relative BUNDLE_GEMFILE is expanded so path is still correct after cd
+      ENV['BUNDLE_GEMFILE'] = File.expand_path(ENV['BUNDLE_GEMFILE']) if ENV['BUNDLE_GEMFILE']
+      `cd '#{rails_app_path}' && #{cmd} 2>&1` 
+    end
     if assert_success && !$?.success?
       puts result
       raise "Expected '#{cmd}' to return a success status.\nOutput: #{result}"
@@ -44,7 +48,7 @@ class TasksTest < ActiveSupport::TestCase
   end
 
   test 'rails perf:library from git' do
-    # BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:<linenumber>
+    # BUNDLE_GEMFILE="gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:<linenumber>
 
     skip # unless ENV['USING_RAILS_GIT']
 
@@ -54,7 +58,7 @@ class TasksTest < ActiveSupport::TestCase
   end
 
   test "rails perf:library with bad script" do
-    # BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:<linenumber>
+    # BUNDLE_GEMFILE="gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:<linenumber>
 
     skip # unless ENV['USING_RAILS_GIT']
 

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -14,7 +14,6 @@ class TasksTest < ActiveSupport::TestCase
   end
 
   def run!(cmd)
-    puts "Running: #{cmd}"
     out = `#{cmd}`
     raise "Could not run #{cmd}, output: #{out}" unless $?.success?
     out
@@ -25,7 +24,6 @@ class TasksTest < ActiveSupport::TestCase
     env             = options[:env]           || {}
     env_string = env.map {|key, value| "#{key.shellescape}=#{value.to_s.shellescape}" }.join(" ")
     cmd        = "env #{env_string} bundle exec rake -f perf.rake #{cmd} --trace"
-    puts "Running: #{cmd}"
     result = Bundler.with_original_env do
       # Ensure relative BUNDLE_GEMFILE is expanded so path is still correct after cd
       ENV['BUNDLE_GEMFILE'] = File.expand_path(ENV['BUNDLE_GEMFILE']) if ENV['BUNDLE_GEMFILE']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require 'bundler/setup'
 # Configure Rails Envinronment
 ENV["RAILS_ENV"] = "test"
 
-
 require "ruby2_keywords" if RUBY_VERSION < "2.7"
 
 require 'rails'
@@ -18,7 +17,6 @@ require 'pathname'
 require 'derailed_benchmarks'
 
 require File.expand_path("../rails_app/config/environment.rb",  __FILE__)
-require "rails/test_help"
 
 ActionMailer::Base.delivery_method    = :test
 ActionMailer::Base.perform_deliveries = true


### PR DESCRIPTION
- fixes #226
- update all relevant examples to indicate pwd is no longer mandatory
- reduce test verbosity, making it easier to scan for issues
- remove duplicate `require` in `test_helper` that obscures when `rails/test_help` is actually loaded
