### PR TITLE
Update derailed_benchmarks.gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## HEAD
 
 - Support REQUEST_METHOD, REQUEST_BODY, CONTENT_TYPE, and CONTENT_LENGTH env vars (https://github.com/zombocom/derailed_benchmarks/pull/234, https://github.com/zombocom/derailed_benchmarks/pull/122)
-- Support ruby-statistics 4.x (https://github.com/zombocom/derailed_benchmarks/pull/238, https://github.com/zombocom/derailed_benchmarks/pull/239)
+- Support ruby-statistics 4.x (https://github.com/zombocom/derailed_benchmarks/pull/238, 
+    https://github.com/zombocom/derailed_benchmarks/pull/239, https://github.com/zombocom/derailed_benchmarks/pull/247)
 - Repair tests, support ruby-statistics in ruby < 3.0 (https://github.com/zombocom/derailed_benchmarks/pull/241)
 - Test Rails 7.1 and 7.2 (https://github.com/zombocom/derailed_benchmarks/pull/242)
 - Switch from dead_end to syntax_suggest (https://github.com/zombocom/derailed_benchmarks/pull/243)

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
   if RUBY_VERSION >= '3.0'
-    gem.add_dependency "ruby-statistics", ">= 4.0"
+    gem.add_dependency "ruby-statistics", ">= 4.0.1"
   else
     gem.add_dependency "ruby-statistics", ">= 2.1"
   end


### PR DESCRIPTION
probably rare issue, but its better to intentionally specify ruby-statistics 4.0.1 or greater, because thats the first version where the rename actually is in effect 
see https://github.com/estebanz01/ruby-statistics/pull/144 

I confirmed that if we specifically bundle 4.0.0 in ruby 3.0+, it breaks:
![image](https://github.com/user-attachments/assets/64f4bb8a-634c-44e6-9e03-9cb9bde82fcf)
