### PR TITLE
Introduce DERAILED_REQUIRE_APPLICATION

### DIFF
--- a/bin/derailed
+++ b/bin/derailed
@@ -80,7 +80,9 @@ class DerailedBenchmarkCLI < Thor
       require 'bundler/setup'
 
       begin
-        if ENV["DERAILED_SKIP_RAILS_REQUIRES"]
+        if ENV["DERAILED_REQUIRE_APPLICATION"]
+          require "./config/application"
+        elsif ENV["DERAILED_SKIP_RAILS_REQUIRES"]
           # do nothing. your app will handle requiring Rails for booting.
         elsif ENV["DERAILED_SKIP_ACTIVE_RECORD"]
           require "action_controller/railtie"


### PR DESCRIPTION
## Problem

This came about because when I run `rake bundle:mem`, it loads `rails/all`, and then it looks like we are loading action_mailbox and other rails gems that we void.

There are a bunch of options in this gem. If there is another way of determining this information, please point the way.

## Description

For rails, `config/application` initializes the application.

`DERAILED_REQUIRE_APPLICATION` gives the developer the option to use the `application.rb` file to load all requires.

Do note, the existing Bundler.require(*env) will be a no-op.

```
DERAILED_REQUIRE_APPLICATION=true bundle exec derailed bundle:mem
```

(included above text for those following along - you know all this)

## Alt Solution

```diff
-        if ENV["DERAILED_REQUIRE_APPLICATION"]
-          require "./config/application"
+        if ENV["DERAILED_REQUIRE"]
+          require ENV["DERAILED_REQUIRE"]
```

This provides non-rails use, but it does look a little bit of a brakeman nightmare.
Let me know which way you want to go.


Thanks for all the good ruby stuff