### PR TITLE
Fallback to Thread::Backtrace::Location#path when #absolute_path is nil

### DIFF
--- a/lib/derailed_benchmarks/core_ext/kernel_require.rb
+++ b/lib/derailed_benchmarks/core_ext/kernel_require.rb
@@ -35,7 +35,8 @@ module Kernel
     if Pathname.new(file).absolute?
       require file
     else
-      require File.expand_path("../#{file}", caller_locations(1, 1)[0].absolute_path)
+      path = caller_locations(1, 1)[0].absolute_path || caller_locations(1, 1)[0].path
+      require File.expand_path("../#{file}", path)
     end
   end
 


### PR DESCRIPTION
Hi there!

For some reasons sometimes `Thread::Backtrace::Location#absolute_path` is nil.

In this case try to fallback to Thread::Backtrace::Location#path

```sh
caller_locations(1, 1)[0].to_s               => /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/ruby/3.3.0/bundler/gems/health_monitor-45570d6686b9/lib/health_monitor/configuration.rb:25:in `database'
caller_locations(1, 1)[0].absolute_path.to_s => 
caller_locations(1, 1)[0].path.to_s          => /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/ruby/3.3.0/bundler/gems/health_monitor-45570d6686b9/lib/health_monitor/configuration.rb
```

Thank you!