### PR TITLE
Fix gemspec ruby version checks

### DIFF
--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
     gem.add_dependency "ruby-statistics", ">= 2.1"
   end
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
-    gem.add_dependency "syntax_suggest", "~> 1.1.0"
+    gem.add_dependency "syntax_suggest", ">= 1.1.0"
   end
   gem.add_dependency "mini_histogram",  ">= 0.3.0"
   gem.add_dependency "rack-test",       ">= 0"

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -29,12 +29,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack",            ">= 1"
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
-  if RUBY_VERSION >= '3.0'
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
     gem.add_dependency "ruby-statistics", ">= 4.0.1"
   else
     gem.add_dependency "ruby-statistics", ">= 2.1"
   end
-  if RUBY_VERSION < "3.2"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
     gem.add_dependency "syntax_suggest", "~> 1.1.0"
   end
   gem.add_dependency "mini_histogram",  ">= 0.3.0"


### PR DESCRIPTION
- Fixed the logic in the gemspec file to correctly compare the current Ruby version with the required version.
- Replaced string comparison of `RUBY_VERSION` with `Gem::Version` for better semantic version handling.
- Addressed edge cases, such as "3.10" being greater than "3.2".
- Adds flexibility for the syntax_suggest gem version to allow 2.x for Ruby 3.0 & 3.1 (related: #258)

Why:
The previous comparison caused a `LoadError` for `syntax_suggest` on Ruby 3.1.6 due to string-based version comparison. RUBY_VERSION returns a string, not a comparable version, breaking the current comparison in some cases.